### PR TITLE
Remove composer 2 incompatible plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 
 # Install Vapor + Prestissimo (parallel/quicker composer install)
 RUN set -xe && \
-    composer global require hirak/prestissimo && \
     composer global require laravel/vapor-cli && \
     composer clear-cache
 


### PR DESCRIPTION
Composer 2 now supports parallel downloads natively so there's no need to continue using this already incompatible plugin.